### PR TITLE
agario-client added to NPM

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "client"]
-	path = client
-	url = git@github.com:pulviscriptor/agario-client.git

--- a/loader.js
+++ b/loader.js
@@ -1,2 +1,2 @@
-window.Client = require('./client/agario-client.js');
+window.Client = require('agario-client');
 window.EventEmitter = require('events').EventEmitter;


### PR DESCRIPTION
You don't need "client" folder anymore. Just do `npm install agario-client`.
And you can create `package.json` and add `agario-client` as dependence, then `npm install` will install it automatically.
Also check your `Makefile`, it needs to be fixed too somehow.
